### PR TITLE
Adepted spelling of setUp and tearDown methods

### DIFF
--- a/ProphecyTestCase.php
+++ b/ProphecyTestCase.php
@@ -21,7 +21,7 @@ class ProphecyTestCase extends \PHPUnit_Framework_TestCase
         return $this->prophet->prophesize($classOrInterface);
     }
 
-    protected function setup()
+    protected function setUp()
     {
         $this->prophet = new Prophet();
     }
@@ -31,7 +31,7 @@ class ProphecyTestCase extends \PHPUnit_Framework_TestCase
         $this->prophet->checkPredictions();
     }
 
-    protected function teardown()
+    protected function tearDown()
     {
         $this->prophet = null;
     }


### PR DESCRIPTION
PHPUnit users are used to spell the tearUp and tearDown methods camelized and not lowercased. For consistency the spelling should be adepted here.
