### PR TITLE
Fixes #2.

### DIFF
--- a/ProphecyTestCase.php
+++ b/ProphecyTestCase.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Prophecy\PhpUnit;
+namespace Prophecy\PHPUnit;
 
 use Prophecy\Exception\Prediction\PredictionException;
 use Prophecy\Prophet;

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Build Status](https://travis-ci.org/phpspec/prophecy-phpunit.png?branch=master)](https://travis-ci.org/phpspec/prophecy-phpunit)
 
-Prophecy PhpUnit integrates the [Prophecy](https://github.com/phpspec/prophecy) mocking
+Prophecy PHPUnit integrates the [Prophecy](https://github.com/phpspec/prophecy) mocking
 library with [PHPUnit](http://phpunit.de) to provide an easier mocking in your testsuite.
 
 
@@ -11,7 +11,7 @@ library with [PHPUnit](http://phpunit.de) to provide an easier mocking in your t
 ```php
 <?php
 
-use Prophecy\PhpUnit\ProphecyTestCase;
+use Prophecy\PHPUnit\ProphecyTestCase;
 
 class UserTest extends ProphecyTestCase
 {
@@ -33,7 +33,7 @@ class UserTest extends ProphecyTestCase
 
 ### Prerequisites
 
-Prophecy PhpUnit requires PHP 5.3.3 or greater.
+Prophecy PHPUnit requires PHP 5.3.3 or greater.
 
 ### Setup through composer
 

--- a/Tests/Fixtures/Error.php
+++ b/Tests/Fixtures/Error.php
@@ -1,8 +1,8 @@
 <?php
 
-namespace Prophecy\PhpUnit\Tests\Fixtures;
+namespace Prophecy\PHPUnit\Tests\Fixtures;
 
-use Prophecy\PhpUnit\ProphecyTestCase;
+use Prophecy\PHPUnit\ProphecyTestCase;
 
 class Error extends ProphecyTestCase
 {

--- a/Tests/Fixtures/Failure.php
+++ b/Tests/Fixtures/Failure.php
@@ -1,8 +1,8 @@
 <?php
 
-namespace Prophecy\PhpUnit\Tests\Fixtures;
+namespace Prophecy\PHPUnit\Tests\Fixtures;
 
-use Prophecy\PhpUnit\ProphecyTestCase;
+use Prophecy\PHPUnit\ProphecyTestCase;
 
 class Failure extends ProphecyTestCase
 {

--- a/Tests/Fixtures/FailureInTearDown.php
+++ b/Tests/Fixtures/FailureInTearDown.php
@@ -1,8 +1,8 @@
 <?php
 
-namespace Prophecy\PhpUnit\Tests\Fixtures;
+namespace Prophecy\PHPUnit\Tests\Fixtures;
 
-use Prophecy\PhpUnit\ProphecyTestCase;
+use Prophecy\PHPUnit\ProphecyTestCase;
 
 class FailureInTearDown extends ProphecyTestCase
 {

--- a/Tests/Fixtures/SetupOverride.php
+++ b/Tests/Fixtures/SetupOverride.php
@@ -1,8 +1,8 @@
 <?php
 
-namespace Prophecy\PhpUnit\Tests\Fixtures;
+namespace Prophecy\PHPUnit\Tests\Fixtures;
 
-use Prophecy\PhpUnit\ProphecyTestCase;
+use Prophecy\PHPUnit\ProphecyTestCase;
 
 class SetupOverride extends ProphecyTestCase
 {

--- a/Tests/Fixtures/Success.php
+++ b/Tests/Fixtures/Success.php
@@ -1,8 +1,8 @@
 <?php
 
-namespace Prophecy\PhpUnit\Tests\Fixtures;
+namespace Prophecy\PHPUnit\Tests\Fixtures;
 
-use Prophecy\PhpUnit\ProphecyTestCase;
+use Prophecy\PHPUnit\ProphecyTestCase;
 
 class Success extends ProphecyTestCase
 {

--- a/Tests/ProphecyTestCaseTest.php
+++ b/Tests/ProphecyTestCaseTest.php
@@ -1,12 +1,12 @@
 <?php
 
-namespace Prophecy\PhpUnit\Tests;
+namespace Prophecy\PHPUnit\Tests;
 
-use Prophecy\PhpUnit\Tests\Fixtures\Error;
-use Prophecy\PhpUnit\Tests\Fixtures\Failure;
-use Prophecy\PhpUnit\Tests\Fixtures\FailureInTearDown;
-use Prophecy\PhpUnit\Tests\Fixtures\SetupOverride;
-use Prophecy\PhpUnit\Tests\Fixtures\Success;
+use Prophecy\PHPUnit\Tests\Fixtures\Error;
+use Prophecy\PHPUnit\Tests\Fixtures\Failure;
+use Prophecy\PHPUnit\Tests\Fixtures\FailureInTearDown;
+use Prophecy\PHPUnit\Tests\Fixtures\SetupOverride;
+use Prophecy\PHPUnit\Tests\Fixtures\Success;
 
 class ProphecyTestCaseTest extends \PHPUnit_Framework_TestCase
 {

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
     "name": "phpspec/prophecy-phpunit",
-    "description": "PhpUnit test case integrating the Prophecy mocking library",
-    "keywords": ["Phpunit", "Prophecy"],
+    "description": "PHPUnit test case integrating the Prophecy mocking library",
+    "keywords": ["PHPUnit", "Prophecy"],
     "homepage": "http://phpspec.org",
     "type": "library",
     "license": "MIT",
@@ -19,10 +19,10 @@
     },
     "autoload": {
         "psr-0": {
-            "Prophecy\\PhpUnit\\": ""
+            "Prophecy\\PHPUnit\\": ""
         }
     },
-    "target-dir": "Prophecy/PhpUnit",
+    "target-dir": "Prophecy/PHPUnit",
     "extra": {
         "branch-alias": {
             "dev-master": "1.0.x-dev"

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -2,7 +2,7 @@
 
 <phpunit colors="true" bootstrap="vendor/autoload.php">
     <testsuites>
-        <testsuite name="Prophecy PhpUnit Test Suite">
+        <testsuite name="Prophecy PHPUnit Test Suite">
             <directory suffix="Test.php">./Tests/</directory>
         </testsuite>
     </testsuites>


### PR DESCRIPTION
Use consistent casing for the PHPUnit name.
