### PR TITLE
Change to abstract class

### DIFF
--- a/ProphecyTestCase.php
+++ b/ProphecyTestCase.php
@@ -5,7 +5,7 @@ namespace Prophecy\PhpUnit;
 use Prophecy\Exception\Prediction\PredictionException;
 use Prophecy\Prophet;
 
-class ProphecyTestCase extends \PHPUnit_Framework_TestCase
+abstract class ProphecyTestCase extends \PHPUnit_Framework_TestCase
 {
     /**
      * @var Prophet


### PR DESCRIPTION
PHPUnit_Framework_TestSuite misunderstood ProphecyTestCase as real test
case when it reads test file and autoloader includes ProphecyTestCase on that file.

phpunit will output mysterious warning when occurred above issue.

```
1) Warning
No tests found in class "Prophecy\PhpUnit\ProphecyTestCase".
```

workaround is require ProphecyTestCase.php at first. 
abstract class would be better for many cases.

see also:
https://github.com/sebastianbergmann/phpunit/blob/3.7/PHPUnit/Util/Class.php#L65
https://github.com/sebastianbergmann/phpunit/blob/3.7/PHPUnit/Framework/TestSuite.php#L314
