### PR TITLE
Move test case methods into a trait

### DIFF
--- a/ProphecyTestCase.php
+++ b/ProphecyTestCase.php
@@ -2,51 +2,7 @@
 
 namespace Prophecy\PhpUnit;
 
-use Prophecy\Exception\Prediction\PredictionException;
-use Prophecy\Prophet;
-
 abstract class ProphecyTestCase extends \PHPUnit_Framework_TestCase
 {
-    /**
-     * @var Prophet
-     */
-    private $prophet;
-
-    /**
-     * @param string|null $classOrInterface
-     * @return \Prophecy\Prophecy\ObjectProphecy
-     * @throws \LogicException
-     */
-    protected function prophesize($classOrInterface = null)
-    {
-        if (null === $this->prophet) {
-            throw new \LogicException(sprintf('The setUp method of %s must be called to initialize Prophecy.', __CLASS__));
-        }
-
-        return $this->prophet->prophesize($classOrInterface);
-    }
-
-    protected function setUp()
-    {
-        $this->prophet = new Prophet();
-    }
-
-    protected function assertPostConditions()
-    {
-        $this->prophet->checkPredictions();
-    }
-
-    protected function tearDown()
-    {
-        $this->prophet = null;
-    }
-
-    protected function onNotSuccessfulTest(\Exception $e)
-    {
-        if ($e instanceof PredictionException) {
-            $e = new \PHPUnit_Framework_AssertionFailedError($e->getMessage(), $e->getCode(), $e);
-        }
-
-        return parent::onNotSuccessfulTest($e);
-    }
+    use ProphecyTrait;
 }

--- a/ProphecyTrait.php
+++ b/ProphecyTrait.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace Prophecy\PhpUnit;
+
+use Prophecy\Exception\Prediction\PredictionException;
+use Prophecy\Prophet;
+
+trait ProphecyTrait
+{
+    /**
+     * @var Prophet
+     */
+    private $prophet;
+
+    /**
+     * @param string|null $classOrInterface
+     * @return \Prophecy\Prophecy\ObjectProphecy
+     * @throws \LogicException
+     */
+    protected function prophesize($classOrInterface = null)
+    {
+        if (null === $this->prophet) {
+            throw new \LogicException(sprintf('The setUp method of %s must be called to initialize Prophecy.', __CLASS__));
+        }
+
+        return $this->prophet->prophesize($classOrInterface);
+    }
+
+    protected function setUp()
+    {
+        $this->prophet = new Prophet();
+    }
+
+    protected function assertPostConditions()
+    {
+        $this->prophet->checkPredictions();
+    }
+
+    protected function tearDown()
+    {
+        $this->prophet = null;
+    }
+
+    protected function onNotSuccessfulTest(\Exception $e)
+    {
+        if ($e instanceof PredictionException) {
+            $e = new \PHPUnit_Framework_AssertionFailedError($e->getMessage(), $e->getCode(), $e);
+        }
+
+        return parent::onNotSuccessfulTest($e);
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -9,6 +9,10 @@
         {
             "name": "Christophe Coevoet",
             "email": "stof@notk.org"
+        },
+        {
+            "name": "Mike Fisher",
+            "email": "mike@mbfisher.com"
         }
     ],
     "require": {


### PR DESCRIPTION
This PR moves the functionality of the TestCase into a trait. This allows you to include it in any `PHPUnit_Framework_TestCase` instance without having to extend `ProphecyTestCase`.

M
