### PR TITLE
Update for PHPUnit 9.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,4 +8,4 @@ php:
 
 install: composer install
 
-script: phpunit --coverage-text
+script: ./vendor/bin/phpunit --coverage-text

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,11 +3,8 @@ language: php
 sudo: false
 
 php:
-    - 5.3
-    - 5.4
-    - 5.5
-    - 5.6
-    - hhvm
+    - 7.3
+    - 7.4
 
 install: composer install
 

--- a/ProphecyTestCase.php
+++ b/ProphecyTestCase.php
@@ -14,7 +14,7 @@ use Prophecy\Prophet;
 abstract class ProphecyTestCase extends TestCase
 {
     /**
-     * @var Prophet
+     * @var Prophet|null
      */
     private $prophet;
 

--- a/ProphecyTestCase.php
+++ b/ProphecyTestCase.php
@@ -55,7 +55,10 @@ abstract class ProphecyTestCase extends TestCase
         }
     }
 
-    protected function tearDown(): void
+    /**
+     * @after
+     */
+    protected function prophecyTearDown(): void
     {
         if (null !== $this->prophet && !$this->prophecyAssertionsCounted) {
             // Some Prophecy assertions may have been done in tests themselves even when a failure happened before checking mock objects.

--- a/ProphecyTestCase.php
+++ b/ProphecyTestCase.php
@@ -19,6 +19,11 @@ abstract class ProphecyTestCase extends TestCase
     private $prophet;
 
     /**
+     * @var bool
+     */
+    private $prophecyAssertionsCounted = false;
+
+    /**
      * @throws DoubleException
      * @throws InterfaceNotFoundException
      *
@@ -50,8 +55,20 @@ abstract class ProphecyTestCase extends TestCase
         }
     }
 
+    protected function tearDown(): void
+    {
+        if (null !== $this->prophet && !$this->prophecyAssertionsCounted) {
+            // Some Prophecy assertions may have been done in tests themselves even when a failure happened before checking mock objects.
+            $this->countProphecyAssertions();
+        }
+
+        $this->prophet = null;
+    }
+
     private function countProphecyAssertions(): void
     {
+        $this->prophecyAssertionsCounted = true;
+
         foreach ($this->prophet->getProphecies() as $objectProphecy) {
             foreach ($objectProphecy->getMethodProphecies() as $methodProphecies) {
                 foreach ($methodProphecies as $methodProphecy) {

--- a/ProphecyTestCase.php
+++ b/ProphecyTestCase.php
@@ -1,4 +1,5 @@
 <?php declare(strict_types=1);
+
 namespace Prophecy\PhpUnit;
 
 use PHPUnit\Framework\AssertionFailedError;

--- a/ProphecyTestCase.php
+++ b/ProphecyTestCase.php
@@ -37,14 +37,16 @@ abstract class ProphecyTestCase extends TestCase
     {
         parent::verifyMockObjects();
 
-        if ($this->prophet !== null) {
-            try {
-                $this->prophet->checkPredictions();
-            } catch (PredictionException $e) {
-                throw new AssertionFailedError($e->getMessage());
-            } finally {
-                $this->countProphecyAssertions();
-            }
+        if ($this->prophet === null) {
+            return;
+        }
+
+        try {
+            $this->prophet->checkPredictions();
+        } catch (PredictionException $e) {
+            throw new AssertionFailedError($e->getMessage());
+        } finally {
+            $this->countProphecyAssertions();
         }
     }
 

--- a/ProphecyTestCase.php
+++ b/ProphecyTestCase.php
@@ -30,7 +30,7 @@ abstract class ProphecyTestCase extends TestCase
             $this->recordDoubledType($classOrInterface);
         }
 
-        return $this->prophet()->prophesize($classOrInterface);
+        return $this->getProphet()->prophesize($classOrInterface);
     }
 
     protected function verifyMockObjects(): void
@@ -61,7 +61,7 @@ abstract class ProphecyTestCase extends TestCase
         }
     }
 
-    private function prophet(): Prophet
+    private function getProphet(): Prophet
     {
         if ($this->prophet === null) {
             $this->prophet = new Prophet;

--- a/Tests/ProphecyTestCaseTest.php
+++ b/Tests/ProphecyTestCaseTest.php
@@ -1,4 +1,5 @@
 <?php declare(strict_types=1);
+
 namespace Prophecy\PhpUnit\Tests;
 
 use PHPUnit\Framework\TestCase;

--- a/Tests/ProphecyTestCaseTest.php
+++ b/Tests/ProphecyTestCaseTest.php
@@ -1,63 +1,70 @@
-<?php
-
+<?php declare(strict_types=1);
 namespace Prophecy\PhpUnit\Tests;
 
+use PHPUnit\Framework\TestCase;
 use Prophecy\PhpUnit\Tests\Fixtures\Error;
 use Prophecy\PhpUnit\Tests\Fixtures\MockFailure;
 use Prophecy\PhpUnit\Tests\Fixtures\SpyFailure;
 use Prophecy\PhpUnit\Tests\Fixtures\Success;
 
-class ProphecyTestCaseTest extends \PHPUnit_Framework_TestCase
+/**
+ * @covers \Prophecy\PhpUnit\ProphecyTestCase
+ */
+final class ProphecyTestCaseTest extends TestCase
 {
-    protected function setUp()
+    protected function setUp(): void
     {
-        // Define the constant because our tests are running PHPUnit testcases themselves
-        if (!defined('PHPUNIT_TESTSUITE')) {
-            define('PHPUNIT_TESTSUITE', true);
+        // Define the constant because our tests are running PHPUnit test cases themselves
+        if (!\defined('PHPUNIT_TESTSUITE')) {
+            \define('PHPUNIT_TESTSUITE', true);
         }
     }
 
-    public function testSuccess()
+    public function testSuccess(): void
     {
         $test = new Success('testMethod');
+
         $result = $test->run();
 
-        $this->assertEquals(0, $result->errorCount());
-        $this->assertEquals(0, $result->failureCount());
+        $this->assertSame(0, $result->errorCount());
+        $this->assertSame(0, $result->failureCount());
         $this->assertCount(1, $result);
-        $this->assertEquals(1, $test->getNumAssertions());
+        $this->assertSame(1, $test->getNumAssertions());
     }
 
-    public function testSpyPredictionFailure()
+    public function testSpyPredictionFailure(): void
     {
         $test = new SpyFailure('testMethod');
+
         $result = $test->run();
 
-        $this->assertEquals(0, $result->errorCount());
-        $this->assertEquals(1, $result->failureCount());
+        $this->assertSame(0, $result->errorCount());
+        $this->assertSame(1, $result->failureCount());
         $this->assertCount(1, $result);
-        $this->assertEquals(1, $test->getNumAssertions());
+        $this->assertSame(1, $test->getNumAssertions());
     }
 
-    public function testMockPredictionFailure()
+    public function testMockPredictionFailure(): void
     {
         $test = new MockFailure('testMethod');
+
         $result = $test->run();
 
-        $this->assertEquals(0, $result->errorCount());
-        $this->assertEquals(1, $result->failureCount());
+        $this->assertSame(0, $result->errorCount());
+        $this->assertSame(1, $result->failureCount());
         $this->assertCount(1, $result);
-        $this->assertEquals(1, $test->getNumAssertions());
+        $this->assertSame(1, $test->getNumAssertions());
     }
 
-    public function testDoublingError()
+    public function testDoublingError(): void
     {
         $test = new Error('testMethod');
+
         $result = $test->run();
 
-        $this->assertEquals(1, $result->errorCount());
-        $this->assertEquals(0, $result->failureCount());
+        $this->assertSame(1, $result->errorCount());
+        $this->assertSame(0, $result->failureCount());
         $this->assertCount(1, $result);
-        $this->assertEquals(0, $test->getNumAssertions());
+        $this->assertSame(0, $test->getNumAssertions());
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -14,11 +14,9 @@
     "minimum-stability": "dev",
     "prefer-stable": true,
     "require": {
-        "php": ">=5.3.3",
-        "phpspec/prophecy": "~1.3"
-    },
-    "suggest": {
-        "phpunit/phpunit": "if it is not installed globally"
+        "php": "^7.3",
+        "phpspec/prophecy": "^1.3",
+        "phpunit/phpunit":"^9.1"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -11,6 +11,8 @@
             "email": "stof@notk.org"
         }
     ],
+    "minimum-stability": "dev",
+    "prefer-stable": true,
     "require": {
         "php": ">=5.3.3",
         "phpspec/prophecy": "~1.3"

--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-master": "1.0.x-dev"
+            "dev-master": "2.0-dev"
         }
     }
 }


### PR DESCRIPTION
Second attempt, this time with minimal changes. Feel free to pick from this what you need/want.

Please note that the `testSpyPredictionFailure()` test fails, I do not know why.

I will deprecate PHPUnit's built-in integration in its `master` branch (to be released as PHPUnit 9.1 on April 3, 2020) soon and trust that this integration will be ready in time.

I am sorry for any inconvenience caused and will try to help with any further work to the best of my ability.