### PR TITLE
Add a trait with most of the implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,3 +49,29 @@ The special ``ProphecyTestCase`` exposes a method ``prophesize($classOrInterface
 to use Prophecy.
 For the usage of the Prophecy doubles, please refer to the [Prophecy documentation](https://github.com/phpspec/prophecy).
 
+If you need to use the Prophecy integration alongside a custom base TestCase rather than the PHPUnit one, a trait is available with all the necessary logic, except the override of the PHPUnit `verifyMockObjects` method (which cannot be provided by a trait). Use it like that:
+
+```php
+<?php
+
+namespace App;
+
+use Prophecy\PhpUnit\ProphecyTrait;
+
+class MyCustomTest extends ExternalTestCase
+{
+    use ProphecyTrait;
+
+    protected function verifyMockObjects(): void
+    {
+        parent::verifyMockObjects();
+
+        $this->verifyProphecyDoubles();
+    }
+
+    public function testSomething()
+    {
+        // You have the same features than when extending ProphecyTestCase now.
+    }
+}
+```

--- a/src/ProphecyTestCase.php
+++ b/src/ProphecyTestCase.php
@@ -2,93 +2,16 @@
 
 namespace Prophecy\PhpUnit;
 
-use PHPUnit\Framework\AssertionFailedError;
 use PHPUnit\Framework\TestCase;
-use Prophecy\Exception\Doubler\DoubleException;
-use Prophecy\Exception\Doubler\InterfaceNotFoundException;
-use Prophecy\Exception\Prediction\PredictionException;
-use Prophecy\Prophecy\MethodProphecy;
-use Prophecy\Prophecy\ObjectProphecy;
-use Prophecy\Prophet;
 
 abstract class ProphecyTestCase extends TestCase
 {
-    /**
-     * @var Prophet|null
-     */
-    private $prophet;
-
-    /**
-     * @var bool
-     */
-    private $prophecyAssertionsCounted = false;
-
-    /**
-     * @throws DoubleException
-     * @throws InterfaceNotFoundException
-     *
-     * @psalm-param class-string|null $type
-     */
-    protected function prophesize(?string $classOrInterface = null): ObjectProphecy
-    {
-        if (\is_string($classOrInterface)) {
-            $this->recordDoubledType($classOrInterface);
-        }
-
-        return $this->getProphet()->prophesize($classOrInterface);
-    }
+    use ProphecyTrait;
 
     protected function verifyMockObjects(): void
     {
         parent::verifyMockObjects();
 
-        if ($this->prophet === null) {
-            return;
-        }
-
-        try {
-            $this->prophet->checkPredictions();
-        } catch (PredictionException $e) {
-            throw new AssertionFailedError($e->getMessage());
-        } finally {
-            $this->countProphecyAssertions();
-        }
-    }
-
-    /**
-     * @after
-     */
-    protected function prophecyTearDown(): void
-    {
-        if (null !== $this->prophet && !$this->prophecyAssertionsCounted) {
-            // Some Prophecy assertions may have been done in tests themselves even when a failure happened before checking mock objects.
-            $this->countProphecyAssertions();
-        }
-
-        $this->prophet = null;
-    }
-
-    private function countProphecyAssertions(): void
-    {
-        $this->prophecyAssertionsCounted = true;
-
-        foreach ($this->prophet->getProphecies() as $objectProphecy) {
-            foreach ($objectProphecy->getMethodProphecies() as $methodProphecies) {
-                foreach ($methodProphecies as $methodProphecy) {
-                    \assert($methodProphecy instanceof MethodProphecy);
-
-                    $this->addToAssertionCount(\count($methodProphecy->getCheckedPredictions()));
-                }
-            }
-        }
-    }
-
-    private function getProphet(): Prophet
-    {
-        if ($this->prophet === null) {
-            $this->prophet = new Prophet;
-        }
-
-        return $this->prophet;
+        $this->verifyProphecyDoubles();
     }
 }

--- a/src/ProphecyTrait.php
+++ b/src/ProphecyTrait.php
@@ -1,0 +1,107 @@
+<?php declare(strict_types=1);
+
+namespace Prophecy\PhpUnit;
+
+use PHPUnit\Framework\AssertionFailedError;
+use PHPUnit\Framework\TestCase;
+use Prophecy\Exception\Doubler\DoubleException;
+use Prophecy\Exception\Doubler\InterfaceNotFoundException;
+use Prophecy\Exception\Prediction\PredictionException;
+use Prophecy\Prophecy\MethodProphecy;
+use Prophecy\Prophecy\ObjectProphecy;
+use Prophecy\Prophet;
+
+/**
+ * @mixin TestCase
+ */
+trait ProphecyTrait
+{
+    /**
+     * @var Prophet|null
+     *
+     * @internal
+     */
+    private $prophet;
+
+    /**
+     * @var bool
+     *
+     * @internal
+     */
+    private $prophecyAssertionsCounted = false;
+
+    /**
+     * @throws DoubleException
+     * @throws InterfaceNotFoundException
+     *
+     * @psalm-param class-string|null $type
+     */
+    protected function prophesize(?string $classOrInterface = null): ObjectProphecy
+    {
+        if (\is_string($classOrInterface)) {
+            \assert($this instanceof TestCase);
+            $this->recordDoubledType($classOrInterface);
+        }
+
+        return $this->getProphet()->prophesize($classOrInterface);
+    }
+
+    private function verifyProphecyDoubles(): void
+    {
+        if ($this->prophet === null) {
+            return;
+        }
+
+        try {
+            $this->prophet->checkPredictions();
+        } catch (PredictionException $e) {
+            throw new AssertionFailedError($e->getMessage());
+        } finally {
+            $this->countProphecyAssertions();
+        }
+    }
+
+    /**
+     * @after
+     */
+    protected function prophecyTearDown(): void
+    {
+        if (null !== $this->prophet && !$this->prophecyAssertionsCounted) {
+            // Some Prophecy assertions may have been done in tests themselves even when a failure happened before checking mock objects.
+            $this->countProphecyAssertions();
+        }
+
+        $this->prophet = null;
+    }
+
+    /**
+     * @internal
+     */
+    private function countProphecyAssertions(): void
+    {
+        \assert($this instanceof TestCase);
+        $this->prophecyAssertionsCounted = true;
+
+        foreach ($this->prophet->getProphecies() as $objectProphecy) {
+            foreach ($objectProphecy->getMethodProphecies() as $methodProphecies) {
+                foreach ($methodProphecies as $methodProphecy) {
+                    \assert($methodProphecy instanceof MethodProphecy);
+
+                    $this->addToAssertionCount(\count($methodProphecy->getCheckedPredictions()));
+                }
+            }
+        }
+    }
+
+    /**
+     * @internal
+     */
+    private function getProphet(): Prophet
+    {
+        if ($this->prophet === null) {
+            $this->prophet = new Prophet;
+        }
+
+        return $this->prophet;
+    }
+}


### PR DESCRIPTION
This makes it easier to add Prophecy support when needing to extend a testcase providing other features (many frameworks are shipping their own base test cases).