### PR TITLE
Add support for Phpunit 10

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 vendor
 composer.lock
 phpunit.xml
+.*.cache

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,8 @@
+# 2.1.0 / TBA
+
+Add support for PHPUnit 10.1+ (10.0 is not supported)
+Bump requirement to Prophecy 1.18+
+
 # 2.0.2 / 2023-04-18
 
 Add the `@not-deprecated` annotation to avoid phpstan reporting `prophesize` as deprecated due to the TestCase deprecation.

--- a/composer.json
+++ b/composer.json
@@ -15,8 +15,8 @@
     "prefer-stable": true,
     "require": {
         "php": "^7.3 || ^8",
-        "phpspec/prophecy": "^1.3",
-        "phpunit/phpunit":"^9.1"
+        "phpspec/prophecy": "^1.18",
+        "phpunit/phpunit":"^9.1 || ^10.1"
     },
     "autoload": {
         "psr-4": {

--- a/fixtures/NoClass.php
+++ b/fixtures/NoClass.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Prophecy\PhpUnit\Tests\Fixtures;
+
+use PHPUnit\Framework\TestCase;
+use Prophecy\PhpUnit\ProphecyTrait;
+
+class NoClass extends TestCase
+{
+    use ProphecyTrait;
+
+    public function testProphesizeWithoutArguments(): void
+    {
+        $prophecy = $this->prophesize()->reveal();
+        
+        $this->assertInstanceOf(\stdClass::class, $prophecy);
+    }
+}

--- a/src/ProphecyTrait.php
+++ b/src/ProphecyTrait.php
@@ -39,7 +39,14 @@ trait ProphecyTrait
      */
     protected function prophesize(?string $classOrInterface = null): ObjectProphecy
     {
-        if (\is_string($classOrInterface)) {
+        static $isPhpUnit9;
+        $isPhpUnit9 = $isPhpUnit9 ?? method_exists($this, 'recordDoubledType');
+
+        if (! $isPhpUnit9) {
+            // PHPUnit 10.1
+            $this->registerFailureType(PredictionException::class);
+        } elseif (\is_string($classOrInterface)) {
+            // PHPUnit 9
             \assert($this instanceof TestCase);
             $this->recordDoubledType($classOrInterface);
         }

--- a/tests/MockFailure.phpt
+++ b/tests/MockFailure.phpt
@@ -9,6 +9,8 @@ require_once __DIR__ . '/run_test.php';
 --EXPECTF--
 PHPUnit %s
 
+Runtime: %s
+
 F %s 1 / 1 (100%)
 
 Time: %s

--- a/tests/NoClass.phpt
+++ b/tests/NoClass.phpt
@@ -1,11 +1,11 @@
 --TEST--
-A test without Prophecy is executed with no additional assertions counted 
+A test with a Prophecy called without any argument 
 --FILE--
 <?php
 
 require_once __DIR__ . '/run_test.php';
 
-\Prophecy\PhpUnit\Tests\runTest('NoProphecy');
+\Prophecy\PhpUnit\Tests\runTest('NoClass');
 --EXPECTF--
 PHPUnit %s
 

--- a/tests/SpyFailure.phpt
+++ b/tests/SpyFailure.phpt
@@ -9,6 +9,8 @@ require_once __DIR__ . '/run_test.php';
 --EXPECTF--
 PHPUnit %s
 
+Runtime: %s
+
 F %s 1 / 1 (100%)
 
 Time: %a
@@ -16,11 +18,11 @@ Time: %a
 There was 1 failure:
 
 1) Prophecy\PhpUnit\Tests\Fixtures\SpyFailure::testMethod
-No calls have been made that match:
+%ao calls have been made that match:
   Double\DateTime\P1->format(exact("Y-m-d"))
 but expected at least one.
 
-%s/tests/run_test.php:%d
+%a/tests/run_test.php:%d
 
 FAILURES!
 Tests: 1, Assertions: 1, Failures: 1.

--- a/tests/Success.phpt
+++ b/tests/Success.phpt
@@ -9,6 +9,8 @@ require_once __DIR__ . '/run_test.php';
 --EXPECTF--
 PHPUnit %s
 
+Runtime: %s
+
 . %s 1 / 1 (100%)
 
 Time: %s

--- a/tests/WrongCall.phpt
+++ b/tests/WrongCall.phpt
@@ -9,6 +9,8 @@ require_once __DIR__ . '/run_test.php';
 --EXPECTF--
 PHPUnit %s
 
+Runtime: %s
+
 E %s 1 / 1 (100%)
 
 Time: %a

--- a/tests/run_test.php
+++ b/tests/run_test.php
@@ -2,6 +2,7 @@
 
 namespace Prophecy\PhpUnit\Tests;
 
+use PHPUnit\TextUI\Application;
 use PHPUnit\TextUI\Command;
 
 require_once __DIR__ . '/xdebug_filter.php';
@@ -14,5 +15,11 @@ function runTest(string $fixtureName): void
         throw new \InvalidArgumentException('Unable to find test fixture at path ' . $filename);
     }
 
-    (new Command())->run(['phpunit', $filename], false);
+    if (class_exists(Command::class)) {
+        // PHPUnit 9.x
+        (new Command())->run(['phpunit', $filename, '--verbose', '--no-configuration'], false);
+    } else {
+        // PHPUnit 10.x
+        (new Application())->run(['phpunit', $filename, '--no-configuration']);
+    }
 }


### PR DESCRIPTION
This is a rework of #41, after #43.

~As @stof noted there, now the CI is highlighting that, under PHPUnit 10, Prophecy is behaving badly, and rendering an error instead of a failure when a Spy detects an unmet expectation.~

~Apart from that, this PR is complete; I'll try to delve a bit, to understand if that has to be fixed here or on Prophecy.~

PHPUnit 10.1 is now released, including https://github.com/sebastianbergmann/phpunit/issues/5201, and this PR is ready!