### PR TITLE
Add @not-deprecated annotation to avoid PHPStan errors

### DIFF
--- a/src/ProphecyTrait.php
+++ b/src/ProphecyTrait.php
@@ -35,6 +35,7 @@ trait ProphecyTrait
      * @throws InterfaceNotFoundException
      *
      * @psalm-param class-string|null $classOrInterface
+     * @not-deprecated
      */
     protected function prophesize(?string $classOrInterface = null): ObjectProphecy
     {


### PR DESCRIPTION
Context: https://github.com/phpstan/phpstan-deprecation-rules/issues/76
Solution: Add `@not-deprecated` annotation.