### PR TITLE
Include phpspec/prophecy#616 to test against PHPUnit 11

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
     "require": {
         "php": "^7.3 || ^8",
         "phpspec/prophecy": "^1.18",
-        "phpunit/phpunit":"^9.1 || ^10.1"
+        "phpunit/phpunit":"^9.1 || ^10.1 || ^11.0"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -15,9 +15,15 @@
     "prefer-stable": true,
     "require": {
         "php": "^7.3 || ^8",
-        "phpspec/prophecy": "^1.18",
+        "phpspec/prophecy": "dev-allow-phpunit-11 as 1.19",
         "phpunit/phpunit":"^9.1 || ^10.1 || ^11.0"
     },
+    "repositories": [
+        {
+            "type": "vcs",
+            "url": "https://github.com/jean85/prophecy"
+        }
+    ],
     "autoload": {
         "psr-4": {
             "Prophecy\\PhpUnit\\": "src"


### PR DESCRIPTION
This is just a playground for testing against PHPUnit 11. See #59 + phpspec/prophecy#616 for the actual code changes needed.