### PR TITLE
Allow PHPUnit 11

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,4 +63,4 @@ jobs:
         run: composer install --ansi --no-interaction --no-progress
 
       - name: Execute Unit Tests
-        run: vendor/bin/phpunit --coverage-text
+        run: vendor/bin/phpunit

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
     "require": {
         "php": "^7.3 || ^8",
         "phpspec/prophecy": "^1.18",
-        "phpunit/phpunit":"^9.1 || ^10.1"
+        "phpunit/phpunit":"^9.1 || ^10.1 || ^11.0"
     },
     "autoload": {
         "psr-4": {

--- a/src/ProphecyTrait.php
+++ b/src/ProphecyTrait.php
@@ -3,6 +3,8 @@
 namespace Prophecy\PhpUnit;
 
 use PHPUnit\Framework\AssertionFailedError;
+use PHPUnit\Framework\Attributes\After;
+use PHPUnit\Framework\Attributes\PostCondition;
 use PHPUnit\Framework\TestCase;
 use Prophecy\Exception\Doubler\DoubleException;
 use Prophecy\Exception\Doubler\InterfaceNotFoundException;
@@ -57,6 +59,7 @@ trait ProphecyTrait
     /**
      * @postCondition
      */
+    #[PostCondition]
     protected function verifyProphecyDoubles(): void
     {
         if ($this->prophet === null) {
@@ -75,6 +78,7 @@ trait ProphecyTrait
     /**
      * @after
      */
+    #[After]
     protected function tearDownProphecy(): void
     {
         if (null !== $this->prophet && !$this->prophecyAssertionsCounted) {


### PR DESCRIPTION
This PR is the only code change needed to run with PHPUnit 11, but it also requires phpspec/prophecy#616, as proved by #58.